### PR TITLE
Adding support for UTF-8 characters (in Localvar - #77)

### DIFF
--- a/include/CounterEditor.ahk
+++ b/include/CounterEditor.ahk
@@ -2,6 +2,7 @@
 ; Purpose: Counters variable Editor [see Lintalist doc]
 ; Version: 1.0.3
 ; Date:    20140426
+FileEncoding, UTF-8 ; Adding support for UTF-8 characters in LocalVars - otherwise the file-encoding will fallback to ANSI when FileAppend is triggered
 
 #NoTrayIcon
 #SingleInstance, force

--- a/include/LocalBundleEditor.ahk
+++ b/include/LocalBundleEditor.ahk
@@ -2,6 +2,7 @@
 ; Purpose: Local variable Editor [see Lintalist doc]
 ; Version: 1.0.3
 ; Date:    20140426
+FileEncoding, UTF-8 ; Adding support for UTF-8 characters in LocalVars - otherwise the file-encoding will fallback to ANSI when FileAppend is triggered
 
 #NoTrayIcon
 #SingleInstance, force


### PR DESCRIPTION
Adding support for UTF-8 characters in LocalVars - otherwise the file-encoding will fallback to ANSI when FileAppend is triggered