### PR TITLE
Update DateTime.ahk for Date Rolling

### DIFF
--- a/plugins/DateTime.ahk
+++ b/plugins/DateTime.ahk
@@ -1,9 +1,10 @@
 ﻿/* 
 Plugin        : DateTime [Standard Lintalist]
 Purpose       : Insert date and or time, including options for date & time calculations e.g. tomorrows date
-Version       : 1.2
+Version       : 1.3
 
 History:
+- 1.3 Added Date/Time rollovers
 - 1.2 Added date Locale Identifiers (LCID) v1.8 ht dbielz https://github.com/lintalist/lintalist/issues/58 
 - 1.1 Modified for improvement of nested snippets in Lintalist v1.6
 - 1.0 first version
@@ -11,26 +12,60 @@ History:
 
 
 GetSnippetDateTime:
- 	 Loop ; get Date & Time [[DateTime=yy mm dd|2|days|LCID]]
-		{
-		 If (InStr(Clip, "[[DateTime=") = 0) or (A_Index > 100)
+	Loop ; get Date & Time [[DateTime=dddd, MMMM d, yyyy|1|Days|m-th]]
+	{
+		If (InStr(Clip, "[[DateTime=") = 0) or (A_Index > 100)
 			Break
-		 
-		 If (InStr(PluginOptions,"|"))
-			{
-			 FormatTime, DT,, yyyyMMddHHmmss
-			 EnvAdd, DT, % StrSplit(PluginOptions,"|").2, % StrSplit(PluginOptions,"|").3
-			 DTLocale:=StrSplit(PluginOptions,"|").4
-			 FormatTime, DT, %DT% %DTLocale%, % StrSplit(PluginOptions,"|").1
-			}
-		 Else
-			FormatTime, DT,, %PluginOptions%
-		 StringReplace, clip, clip, %PluginText%, %DT%, All
-		 DT:=""
-		 DTLocale:=""
-		 PluginOptions:=""
-		 PluginText:=""
-		 ProcessTextString:=""
 
-	  } 
+		If (InStr(PluginOptions,"|"))
+		{
+			FormatTime, DT,, yyyyMMddHHmmss
+			EnvAdd, DT, % StrSplit(PluginOptions,"|").2, % StrSplit(PluginOptions,"|").3
+			DTLocale := StrSplit(PluginOptions,"|").4
+
+			; Extract day range (e.g. m-th, m-f, etc.) from PluginOptions
+			DayRange := StrSplit(PluginOptions, "|").5
+
+			; Check the range specified by the user
+			DayOfWeek := A_WDay
+			FormatTime, DayOfWeek, %DT%, WDay
+
+			If (DayRange != "")
+			{
+				; Define day mapping for ranges
+				DayMapping := {"su": 1, "m": 2, "tu": 3, "w": 4, "th": 5, "f": 6, "sa": 7}
+
+				; Parse the range (e.g., "m-th" -> start=m, end=th)
+				DayStart := SubStr(DayRange, 1, InStr(DayRange, "-") - 1)
+				DayEnd := SubStr(DayRange, InStr(DayRange, "-") + 1)
+
+				; Get the day numbers from the abbreviations
+				StartDayNum := DayMapping[DayStart]
+				EndDayNum := DayMapping[DayEnd]
+
+				; Adjust if the calculated day falls outside the range
+				If (DayOfWeek < StartDayNum)
+				{
+					; If day is before the range, move to the start of the range
+					EnvAdd, DT, % StartDayNum - DayOfWeek, Days
+				}
+				Else If (DayOfWeek > EndDayNum)
+				{
+					; If day is after the range, move to the start of the next week (adjust by 7 days)
+					EnvAdd, DT, % 7 - (DayOfWeek - StartDayNum), Days
+				}
+			}
+
+			FormatTime, DT, %DT% %DTLocale%, % StrSplit(PluginOptions,"|").1
+		}
+		Else
+			FormatTime, DT,, %PluginOptions%
+
+		StringReplace, clip, clip, %PluginText%, %DT%, All
+		DT := ""
+		DTLocale := ""
+		PluginOptions := ""
+		PluginText := ""
+		ProcessTextString := ""
+	}
 Return

--- a/plugins/DateTime.ahk
+++ b/plugins/DateTime.ahk
@@ -12,7 +12,7 @@ History:
 
 
 GetSnippetDateTime:
-	Loop ; get Date & Time [[DateTime=dddd, MMMM d, yyyy|1|Days|m-th]]
+	Loop ; get Date & Time [[DateTime=dddd, MMMM d, yyyy|1|Days|LCID|mon-thu]]
 	{
 		If (InStr(Clip, "[[DateTime=") = 0) or (A_Index > 100)
 			Break
@@ -23,7 +23,7 @@ GetSnippetDateTime:
 			EnvAdd, DT, % StrSplit(PluginOptions,"|").2, % StrSplit(PluginOptions,"|").3
 			DTLocale := StrSplit(PluginOptions,"|").4
 
-			; Extract day range (e.g. m-th, m-f, etc.) from PluginOptions
+			; Extract day range (e.g. mon-thu (2-5), mon-fri (2-6), etc.) from PluginOptions
 			DayRange := StrSplit(PluginOptions, "|").5
 
 			; Check the range specified by the user
@@ -32,8 +32,12 @@ GetSnippetDateTime:
 
 			If (DayRange != "")
 			{
-				; Define day mapping for ranges
-				DayMapping := {"su": 1, "m": 2, "tu": 3, "w": 4, "th": 5, "f": 6, "sa": 7}
+				
+				; Define day mapping for ranges; allow for 1-7 and sun-sat
+				If RegExMatch(DayRange,"im)[1-7]-")
+					DayMapping := [1, 2, 3, 4, 5, 6, 7]
+				Else
+					DayMapping := {"sun": 1, "mon": 2, "tue": 3, "wed": 4, "thu": 5, "fri": 6, "sat": 7}
 
 				; Parse the range (e.g., "m-th" -> start=m, end=th)
 				DayStart := SubStr(DayRange, 1, InStr(DayRange, "-") - 1)
@@ -54,6 +58,13 @@ GetSnippetDateTime:
 					; If day is after the range, move to the start of the next week (adjust by 7 days)
 					EnvAdd, DT, % 7 - (DayOfWeek - StartDayNum), Days
 				}
+			DayRange := ""
+			DayOfWeek := ""
+			DayMapping := ""
+			DayStart := ""
+			DayEnd := ""
+			StartDayNum := ""
+			EndDayNum := ""
 			}
 
 			FormatTime, DT, %DT% %DTLocale%, % StrSplit(PluginOptions,"|").1

--- a/plugins/DateTime.ahk
+++ b/plugins/DateTime.ahk
@@ -32,17 +32,21 @@ GetSnippetDateTime:
 
 			If (DayRange != "")
 			{
-				
 				; Define day mapping for ranges; allow for 1-7 and sun-sat
-				If RegExMatch(DayRange,"im)[1-7]-")
-					DayMapping := [1, 2, 3, 4, 5, 6, 7]
-				Else
-					DayMapping := {"sun": 1, "mon": 2, "tue": 3, "wed": 4, "thu": 5, "fri": 6, "sat": 7}
+				DayMapping := {"sun": 1, "mon": 2, "tue": 3, "wed": 4, "thu": 5, "fri": 6, "sat": 7
+				, 1: "sun", 2: "mon", 3: "tue", 4: "wed", 5: "thu", 6: "fri", 7: "sat"}
 
 				; Parse the range (e.g., "m-th" -> start=m, end=th)
 				DayStart := SubStr(DayRange, 1, InStr(DayRange, "-") - 1)
 				DayEnd := SubStr(DayRange, InStr(DayRange, "-") + 1)
 
+				; Transform the number to "day" to allow for 7-1 to be used for sat-sun for example
+				If DayStart in 1,2,3,4,5,6,7
+					DayStart:=DayMapping[DayStart]
+
+				If DayEnd in 1,2,3,4,5,6,7
+					DayEnd:=DayMapping[DayEnd]
+				
 				; Get the day numbers from the abbreviations
 				StartDayNum := DayMapping[DayStart]
 				EndDayNum := DayMapping[DayEnd]

--- a/plugins/DateTime.ahk
+++ b/plugins/DateTime.ahk
@@ -36,7 +36,7 @@ GetSnippetDateTime:
 				DayMapping := {"sun": 1, "mon": 2, "tue": 3, "wed": 4, "thu": 5, "fri": 6, "sat": 7
 				, 1: "sun", 2: "mon", 3: "tue", 4: "wed", 5: "thu", 6: "fri", 7: "sat"}
 
-				; Parse the range (e.g., "m-th" -> start=m, end=th)
+				; Parse the range (e.g., "mon-thu" -> start=mon, end=thu)
 				DayStart := SubStr(DayRange, 1, InStr(DayRange, "-") - 1)
 				DayEnd := SubStr(DayRange, InStr(DayRange, "-") + 1)
 


### PR DESCRIPTION
Allows a date/time to roll over. This would update the general format from:

[[DateTime=Format|Value|TimeUnits|LCID]]

To:
[[DateTime=Format|Value|TimeUnits|LCID|RollOver]]

---

Example usage:

Timer until business hours = [[DateTime=dddd, MMMM d, yyyy|1|Days||m-f]] 8:00 AM

---

This would return the following day, in this format (using today, 9/16 as an example): Timer until business hours = Tuesday, September 17, 2024 8:00 AM

However, if the day was Friday and it was used, instead it would return: Timer until business hours = Monday, September 23, 2024 8:00 AM

---

This can be set for any rollover, for example: [[DateTime=dddd, MMMM d, yyyy|1|Days||su-m]] 8:00 AM

Which today (a Monday) would return: Sunday, September 22, 2024 8:00 AM (The cutoff days are Sunday - Monday, because the next day would be Tuesday it instead rolls over to the next available Sunday)