### PR TITLE
Choice: select by digit(1..0) to choose the first 10 items

### DIFF
--- a/include/Editor.ahk
+++ b/include/Editor.ahk
@@ -956,6 +956,7 @@ Gui, 1:-Disabled
 Gui, 71:Destroy
 WinActivate, %AppWindow%
 InEditMode = 0
+EditMode:=""
 ControlFocus, Edit1, %AppWindow%
 If OnTopStateSaved
 	Gosub, GuiOnTopCheck

--- a/lintalist.ahk
+++ b/lintalist.ahk
@@ -2201,6 +2201,9 @@ If (item = "") ; if we didn't focus on results list while "typing to filter" in 
 	 If InStr(item,"`n") ; we may get all the results of the "typing to filter" so assume we want first result
 		item:=Trim(StrSplit(item,"`n").1,"`n`r")
 	}
+; Remove numeric prefix like "1) " when SelectByDigit numbering is shown
+if (SelectByDigit)
+	item := RegExReplace(item, "^\s*\d{1,2}\)\s*")
 Gosub, 10GuiSavePos
 Gui, 10:Destroy
 Gui, PreviewChoice:Destroy

--- a/lintalist.ahk
+++ b/lintalist.ahk
@@ -2201,9 +2201,9 @@ If (item = "") ; if we didn't focus on results list while "typing to filter" in 
 	 If InStr(item,"`n") ; we may get all the results of the "typing to filter" so assume we want first result
 		item:=Trim(StrSplit(item,"`n").1,"`n`r")
 	}
-; Remove numeric prefix like "1) " when SelectByDigit numbering is shown
+; Remove numeric prefix like "1: " when SelectByDigit numbering is shown
 if (SelectByDigit)
-	item := RegExReplace(item, "^\s*\d{1,2}\)\s*")
+	item := RegExReplace(item, "^\d:\s")
 Gosub, 10GuiSavePos
 Gui, 10:Destroy
 Gui, PreviewChoice:Destroy

--- a/lintalist.ahk
+++ b/lintalist.ahk
@@ -2203,7 +2203,16 @@ If (item = "") ; if we didn't focus on results list while "typing to filter" in 
 	}
 ; Remove numeric prefix like "1: " when SelectByDigit numbering is shown
 if (SelectByDigit)
-	item := RegExReplace(item, "^\d:\s")
+	{
+		SendMessage, 0x188, 0, 0, ListBox1, Select and press enter  ; LB_GETCURSEL
+		selIndex := ErrorLevel + 1
+		if (SelectByDigit && selIndex <= 10)
+			{
+			 expected := (selIndex = 10) ? "0: " : selIndex ": "
+			 if (SubStr(item, 1, StrLen(expected)) = expected)
+				item := SubStr(item, StrLen(expected) + 1)
+			}
+	}
 Gosub, 10GuiSavePos
 Gui, 10:Destroy
 Gui, PreviewChoice:Destroy

--- a/lintalist.ahk
+++ b/lintalist.ahk
@@ -999,6 +999,7 @@ If (Script = "") or (ScriptPaused = 1) ; script is empty so we need to paste Tex
 			 else
 				SnippetPasteMethod:=0 ; paste directly
 			 Script:=""
+			 SnippetPasteMethod:=0 ; 19/06/2025 safety
 			}
 
 		 Gosub, ProcessText
@@ -2202,7 +2203,7 @@ If (item = "") ; if we didn't focus on results list while "typing to filter" in 
 		item:=Trim(StrSplit(item,"`n").1,"`n`r")
 	}
 ; Remove numeric prefix like "1: " when SelectByDigit numbering is shown, as we also pad non-digit snippets always remove the first three characters.
-If (SelectByDigit)
+If (SelectByDigit) and (EditMode = "") ; when in edit mode (AppendSnippet,MoveSnippet,CopySnippet) we should strip the selected item of course as it would fail to obtain the correct file name of the bundle
 	{
 		SendMessage, 0x188, 0, 0, ListBox1, Select and press enter  ; LB_GETCURSEL
 		selIndex := ErrorLevel + 1
@@ -2250,6 +2251,7 @@ Return
 MadeChoice = 1
 InEditMode = 0
 EditMode =
+ShorthandPastePart2:=""
 Clip:="" ; in case we cancelled Choice by using the X
 Gosub, 10GuiSavePos
 Gui, 10:Destroy
@@ -2271,6 +2273,8 @@ lasttext:="fadsfSDFDFasdFdfsadfsadFDSFDf"
 ViaText:=0
 ViaShorthand:=0
 OmniSearch:=0
+SnippetPasteMethod:=0
+ShorthandPastePart2:=""
 Return
 
 ; tools from usertools.ini

--- a/lintalist.ahk
+++ b/lintalist.ahk
@@ -2201,17 +2201,12 @@ If (item = "") ; if we didn't focus on results list while "typing to filter" in 
 	 If InStr(item,"`n") ; we may get all the results of the "typing to filter" so assume we want first result
 		item:=Trim(StrSplit(item,"`n").1,"`n`r")
 	}
-; Remove numeric prefix like "1: " when SelectByDigit numbering is shown
-if (SelectByDigit)
+; Remove numeric prefix like "1: " when SelectByDigit numbering is shown, as we also pad non-digit snippets always remove the first three characters.
+If (SelectByDigit)
 	{
 		SendMessage, 0x188, 0, 0, ListBox1, Select and press enter  ; LB_GETCURSEL
 		selIndex := ErrorLevel + 1
-		if (SelectByDigit && selIndex <= 10)
-			{
-			 expected := (selIndex = 10) ? "0: " : selIndex ": "
-			 if (SubStr(item, 1, StrLen(expected)) = expected)
-				item := SubStr(item, StrLen(expected) + 1)
-			}
+		item := SubStr(item, 4)
 	}
 Gosub, 10GuiSavePos
 Gui, 10:Destroy

--- a/plugins/Choice.ahk
+++ b/plugins/Choice.ahk
@@ -75,10 +75,10 @@ MakeChoice:
 		 Gui, 10:Add, ListBox,  xp yp+30 w400 R10 vItem gChoiceMouseOK, %ShownOptions%
 		 Gui, 10:Add, button,   w70       vChoiceCancel gCancelChoice, &Cancel
 		 Gui, 10:Add, button,   xp+75 w80 vChoiceRandom gChoiceRandom, &Random
-		 Gui, 10:Add, Checkbox, xp+90  yp   w106 h30 vChoiceAutoCenter gChoiceAutoCenter, &Auto Center
-		 Gui, 10:Add, Checkbox, xp yp+24   w150 h30 vChoiceInput gChoiceInput, &Use as [[Input]]
+		 Gui, 10:Add, Checkbox, xp+90  yp   w106 h28 vChoiceAutoCenter gChoiceAutoCenter, &Auto Center
+		 Gui, 10:Add, Checkbox, xp yp+24   w150 h28 vChoiceInput gChoiceInput, &Use as [[Input]]
 		 ;Gui, 10:Add, button  , xp+130 yp   w130 vPreview gTogglePreview, 👁 View
-		 Gui, 10:Add, Checkbox, xp yp+24 w160 h30 vSelectByDigit gSelectByDigit, &Select by digit
+		 Gui, 10:Add, Checkbox, xp yp+24 w160 h28 vSelectByDigit gSelectByDigit, &Select by digit
 		 Gui, 10:Add, button,   xp yp default vChoiceOK gChoiceOK hidden, OK
 
 		 Gui, PreviewChoice:Destroy
@@ -338,7 +338,7 @@ Gui10ListboxCheckPosition(gui10title)
 		ControlMove, Listbox1, Gui10ListboxX, Gui10ListboxX, Gui10ListboxWidth, 110, %gui10title%
 	}
 
-; Prefix 1) .. 10) on first up to 10 items in a | delimited list
+; Prefix 1) .. 0) on first up to 10 items in a | delimited list
 AddDigitPrefixes(listStr)
 	{
 		result := ""
@@ -351,7 +351,7 @@ AddDigitPrefixes(listStr)
 			item := A_LoopField
 			if (idx <= 10)
 			{
-				prefix := (idx = 10) ? "10) " : idx ") "
+				prefix := (idx = 10) ? "0: " : idx ": "
 				result .= prefix item "|"
 			}
 			else
@@ -375,43 +375,18 @@ Return
 
 #If (WinActive("Select and press enter ahk_class AutoHotkeyGUI") && SelectByDigit)
 1::
-SelectByDigitN:=1
-Gosub, SelectByDigitChoose
-Return
 2::
-SelectByDigitN:=2
-Gosub, SelectByDigitChoose
-Return
 3::
-SelectByDigitN:=3
-Gosub, SelectByDigitChoose
-Return
 4::
-SelectByDigitN:=4
-Gosub, SelectByDigitChoose
-Return
 5::
-SelectByDigitN:=5
-Gosub, SelectByDigitChoose
-Return
 6::
-SelectByDigitN:=6
-Gosub, SelectByDigitChoose
-Return
 7::
-SelectByDigitN:=7
-Gosub, SelectByDigitChoose
-Return
 8::
-SelectByDigitN:=8
-Gosub, SelectByDigitChoose
-Return
 9::
-SelectByDigitN:=9
-Gosub, SelectByDigitChoose
-Return
 0::
-SelectByDigitN:=10
+SelectByDigitN:=SubStr(A_ThisHotkey,0)
+If (SelectByDigitN = 0)
+	SelectByDigitN:=10
 Gosub, SelectByDigitChoose
 Return
 #If

--- a/plugins/Choice.ahk
+++ b/plugins/Choice.ahk
@@ -8,8 +8,9 @@ Notes         : When "Auto Center" is enabled, the window will always be centere
 
 History:
 - 2.5 Feature: Select by digit (1..0) to choose the first 10 items;
-      shows numeric prefixes 1) .. 10) when enabled; 
+      shows numeric prefixes 1: .. 0: when enabled;
 	  adds optional UI checkbox and hotkeys (Alt+S toggles Select by digit; disabled by default). 
+	  Also enable Alt+digit (Alt+1..0) to select items 1..10 by default in the Choice window; hotkeys only, no change to display or result processing.
 - 2.4 Fix: always had filter option - https://github.com/lintalist/lintalist/issues/314
 - 2.3 Auto-select first item after filtering - https://github.com/lintalist/lintalist/pull/313
 - 2.2 Image Preview window with filelist - https://github.com/lintalist/lintalist/issues/239 (only works with fullpath option, P).

--- a/plugins/Choice.ahk
+++ b/plugins/Choice.ahk
@@ -8,9 +8,8 @@ Notes         : When "Auto Center" is enabled, the window will always be centere
 
 History:
 - 2.5 Feature: Select by digit (1..0) to choose the first 10 items;
-      shows numeric prefixes 1: .. 0: when enabled;
-	  adds optional UI checkbox and hotkeys (Alt+S toggles Select by digit; disabled by default). 
-	  Also enable Alt+digit (Alt+1..0) to select items 1..10 by default in the Choice window; hotkeys only, no change to display or result processing.
+      adds optional UI checkbox and hotkeys (Alt+S toggles Select by digit; disabled by default).
+      Note: SelectByDigitTyping "hidden" setting in settings.ini to be able to use just digit to select shortcut vs alt+digit.
 - 2.4 Fix: always had filter option - https://github.com/lintalist/lintalist/issues/314
 - 2.3 Auto-select first item after filtering - https://github.com/lintalist/lintalist/pull/313
 - 2.2 Image Preview window with filelist - https://github.com/lintalist/lintalist/issues/239 (only works with fullpath option, P).
@@ -63,7 +62,7 @@ MakeChoice:
 			}
 		 PluginOptions:=RegExReplace(PluginOptions,"\|\|*","|",,,2)
 		 MultipleHotkey=0
-		 if (ChoiceQuestion = "")
+		 If (ChoiceQuestion = "")
 			ChoiceQuestion:="Select and press enter"
 		 Gui, 10:Destroy
 		 Gui, 10:+Owner +AlwaysOnTop +Resize +MinSize -SysMenu
@@ -71,15 +70,14 @@ MakeChoice:
 		 Gui, 10:font, s%FontSize%
 		 Gui, 10:Add, Edit,     x5 y5 w400 vChoiceFilterText gChoiceFilterText hwndHED1,
 		 ShownOptions := PluginOptions
-		 if (SelectByDigit)
-		 ShownOptions := AddDigitPrefixes(PluginOptions)
+		 If (SelectByDigit)
+			ShownOptions := AddDigitPrefixes(PluginOptions)
 		 Gui, 10:Add, ListBox,  xp yp+30 w400 R10 vItem gChoiceMouseOK, %ShownOptions%
-		 Gui, 10:Add, button,   w70       vChoiceCancel gCancelChoice, &Cancel
+		 Gui, 10:Add, Checkbox, w106 h28 vChoiceAutoCenter gChoiceAutoCenter, &Auto Center
+		 Gui, 10:Add, Checkbox, xp+120 yp w140 h28 vChoiceInput gChoiceInput, &Use as [[Input]]
+		 Gui, 10:Add, Checkbox, xp+150 yp w150 h28 vSelectByDigit gSelectByDigit, &Select by digit
+		 Gui, 10:Add, button,   x5 w70       vChoiceCancel gCancelChoice, &Cancel
 		 Gui, 10:Add, button,   xp+75 w80 vChoiceRandom gChoiceRandom, &Random
-		 Gui, 10:Add, Checkbox, xp+90  yp   w106 h28 vChoiceAutoCenter gChoiceAutoCenter, &Auto Center
-		 Gui, 10:Add, Checkbox, xp yp+24   w150 h28 vChoiceInput gChoiceInput, &Use as [[Input]]
-		 ;Gui, 10:Add, button  , xp+130 yp   w130 vPreview gTogglePreview, 👁 View
-		 Gui, 10:Add, Checkbox, xp yp+24 w160 h28 vSelectByDigit gSelectByDigit, &Select by digit
 		 Gui, 10:Add, button,   xp yp default vChoiceOK gChoiceOK hidden, OK
 
 		 Gui, PreviewChoice:Destroy
@@ -275,6 +273,7 @@ ChoiceWindowPosition:
 IniRead, ChoiceAutoCenter, %A_ScriptDir%\session.ini, choice, ChoiceAutoCenter, 1
 IniRead, ChoiceInput     , %A_ScriptDir%\session.ini, choice, ChoiceInput, 1
 IniRead, SelectByDigit   , %A_ScriptDir%\session.ini, choice, SelectByDigit, 0
+IniRead, SelectByDigitTyping, %A_ScriptDir%\session.ini, choice, SelectByDigitTyping, 0
 IniRead, ChoiceX         , %A_ScriptDir%\session.ini, choice, ChoiceX, 300
 IniRead, ChoiceY         , %A_ScriptDir%\session.ini, choice, ChoiceY, 300
 IniRead, ChoiceWidth     , %A_ScriptDir%\session.ini, choice, ChoiceWidth, 410
@@ -346,19 +345,16 @@ AddDigitPrefixes(listStr)
 		idx := 0
 		Loop, Parse, listStr, |
 		{
+			prefix:=Chr(8230) Chr(8230) Chr(8230) ; 5760 shows a faint dash
 			if (A_LoopField = "")
 				continue
 			idx++
 			item := A_LoopField
 			if (idx <= 10)
-			{
 				prefix := (idx = 10) ? "0: " : idx ": "
-				result .= prefix item "|"
-			}
-			else
-				result .= item "|"
+			result .= prefix item "|"
 		}
-		return RegExReplace(result, "\|$", "")
+		return RTrim(result, "|")
 	}
 
 #IfWinActive, Select and press enter ahk_class AutoHotkeyGUI
@@ -392,7 +388,7 @@ Gosub, SelectByDigitChoose
 Return
 #IfWinActive
 
-#If (WinActive("Select and press enter ahk_class AutoHotkeyGUI") && SelectByDigit)
+#If (WinActive("Select and press enter ahk_class AutoHotkeyGUI") && SelectByDigit && SelectByDigitTyping)
 1::
 2::
 3::

--- a/plugins/Choice.ahk
+++ b/plugins/Choice.ahk
@@ -200,7 +200,7 @@ UpdatePreview:
 Gui, PreviewChoice:Default
 itemPreview := item
 if (SelectByDigit)
-	itemPreview := RegExReplace(itemPreview, "^\s*(?:10|[1-9])\)\s*")
+	itemPreview := SubStr(itemPreview,4)
 SplitPath, itemPreview, , , OutExtension
 if OutExtension in bmp,gif,ico,jpg,jpeg,png
 	htmdoc:=StrReplace(htmltemplate,"--content--","<img src=file:///" StrReplace(StrReplace(itemPreview," ","%20"),"\","/") "  >")

--- a/plugins/Choice.ahk
+++ b/plugins/Choice.ahk
@@ -373,6 +373,24 @@ else
 Return
 #IfWinActive
 
+#IfWinActive, Select and press enter ahk_class AutoHotkeyGUI
+!1::
+!2::
+!3::
+!4::
+!5::
+!6::
+!7::
+!8::
+!9::
+!0::
+SelectByDigitN:=SubStr(A_ThisHotkey,0)
+If (SelectByDigitN = 0)
+	SelectByDigitN:=10
+Gosub, SelectByDigitChoose
+Return
+#IfWinActive
+
 #If (WinActive("Select and press enter ahk_class AutoHotkeyGUI") && SelectByDigit)
 1::
 2::


### PR DESCRIPTION
Feature: Select by digit (1..0) to choose the first 10 items;
shows numeric prefixes 1) .. 10) when enabled; 
adds optional UI checkbox and hotkeys (Alt+S toggles Select by digit; disabled by default). 

The code is generated by GPT-5 in cursor, and Deepseek helps to fix a little problem for the `SelectByDigitChoose` part.