### PR TITLE
Fix Choice digit prefix leak after editing snippets

### DIFF
--- a/include/Editor.ahk
+++ b/include/Editor.ahk
@@ -794,6 +794,7 @@ Gosub, GetText
 ControlFocus, Edit1, %AppWindow%
 ShowPreview(PreviewSection)
 InEditMode = 0
+EditMode =
 If OnTopStateSaved
 	Gosub, GuiOnTopCheck
 Return
@@ -968,6 +969,7 @@ Gui, 1:-Disabled
 Gui, 71:Destroy
 WinActivate, %AppWindow%
 InEditMode = 0
+EditMode =
 ControlFocus, Edit1, %AppWindow%
 If OnTopStateSaved
 	Gosub, GuiOnTopCheck

--- a/lintalist.ahk
+++ b/lintalist.ahk
@@ -2208,9 +2208,11 @@ If (item = "") ; if we didn't focus on results list while "typing to filter" in 
 	 If InStr(item,"`n") ; we may get all the results of the "typing to filter" so assume we want first result
 		item:=Trim(StrSplit(item,"`n").1,"`n`r")
 	}
-; Remove numeric prefix like "1: " when SelectByDigit numbering is shown in the Choice plugin.
-If (SelectByDigit) and WinActive("Select and press enter ahk_class AutoHotkeyGUI")
+; Remove numeric prefix like "1: " when SelectByDigit numbering is shown, as we also pad non-digit snippets always remove the first three characters.
+If (SelectByDigit) and (EditMode = "") ; when in edit mode (AppendSnippet,MoveSnippet,CopySnippet) we should strip the selected item of course as it would fail to obtain the correct file name of the bundle
 	{
+		SendMessage, 0x188, 0, 0, ListBox1, Select and press enter  ; LB_GETCURSEL
+		selIndex := ErrorLevel + 1
 		item := SubStr(item, 4)
 	}
 Gosub, 10GuiSavePos

--- a/lintalist.ahk
+++ b/lintalist.ahk
@@ -2208,11 +2208,9 @@ If (item = "") ; if we didn't focus on results list while "typing to filter" in 
 	 If InStr(item,"`n") ; we may get all the results of the "typing to filter" so assume we want first result
 		item:=Trim(StrSplit(item,"`n").1,"`n`r")
 	}
-; Remove numeric prefix like "1: " when SelectByDigit numbering is shown, as we also pad non-digit snippets always remove the first three characters.
-If (SelectByDigit) and (EditMode = "") ; when in edit mode (AppendSnippet,MoveSnippet,CopySnippet) we should strip the selected item of course as it would fail to obtain the correct file name of the bundle
+; Remove numeric prefix like "1: " when SelectByDigit numbering is shown in the Choice plugin.
+If (SelectByDigit) and WinActive("Select and press enter ahk_class AutoHotkeyGUI")
 	{
-		SendMessage, 0x188, 0, 0, ListBox1, Select and press enter  ; LB_GETCURSEL
-		selIndex := ErrorLevel + 1
 		item := SubStr(item, 4)
 	}
 Gosub, 10GuiSavePos


### PR DESCRIPTION
This fixes a Choice plugin issue after editing a snippet script.

When "Select by digit" is enabled, Choice displays entries with prefixes such as "1: ". Those prefixes are stripped after selection. However, after editing a snippet, EditMode could remain set to EditSnippet until restart. Because the prefix-stripping logic checked EditMode, the prefix was not removed and could leak into script variables such as llpart1.

Example result before the fix:

E:\Dropbox\ahk\lintalist-upstream\1: E:\Dropbox\ahk\lintalist

This change clears EditMode when leaving the snippet editor and makes the Choice prefix stripping depend on the active Choice window instead of the editor state.
